### PR TITLE
DEPLOY-569: Stable ActiveMQ Chart (used by ACS 6.1)

### DIFF
--- a/activiti-cloud-events-adapter/requirements.yaml
+++ b/activiti-cloud-events-adapter/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: activemq
-    version: ^0.1.0
-    repository: https://kubernetes-charts.alfresco.com/incubator
+    version: ^1.0
+    repository: https://kubernetes-charts.alfresco.com/stable


### PR DESCRIPTION
The ActiveMq chart is now stable. We should update the requirement for the Activiti-Cloud-Events-Adapter chart.