### PR TITLE
provide a way to extend the realm at deploy time

### DIFF
--- a/activiti-keycloak/files/activiti-realm.json
+++ b/activiti-keycloak/files/activiti-realm.json
@@ -72,7 +72,10 @@
       "composite" : false,
       "clientRole" : false,
       "containerId" : "activiti"
-    } ],
+    } {{- range .Values.realm.extraRealmRoles -}}
+      ,
+    {{ . | toJson }}
+      {{- end }} ],
     "client" : {
       "realm-management" : [ {
         "id" : "ede6b429-a4be-4343-a418-ceab9d1387ab",
@@ -302,7 +305,10 @@
     "realmRoles" : [ ],
     "clientRoles" : { },
     "subGroups" : [ ]
-  } ],
+  } {{- range .Values.realm.extraGroups -}}
+  ,
+    {{ . | toJson }}
+    {{- end }}],
   "defaultRoles" : [ "uma_authorization", "offline_access" ],
   "requiredCredentials" : [ "password" ],
   "passwordPolicy" : "hashIterations(20000)",
@@ -561,7 +567,10 @@
     },
     "notBefore" : 0,
     "groups" : [ "/testgroup" ]
-  } ],
+  }{{- range .Values.realm.extraUsers -}}
+  ,
+    {{ . | toJson }}
+    {{- end }} ],
   "clientScopeMappings" : {
     "realm-management" : [ {
       "client" : "admin-cli",
@@ -692,8 +701,8 @@
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
     "secret" : "**********",
-    "redirectUris" : [ "http://placeholder.com", "http://localhost:*", "http://activiti-cloud-demo-ui:*", "http://dummy.com" ],
-    "webOrigins" : [ "http://activiti-cloud-demo-ui:3000", "http://activiti-cloud-sso-idm-kub:30082", "http://activiti-cloud-demo-ui:30082", "http://localhost:3000" ],
+    "redirectUris" : {{ .Values.realm.activiti.redirectUris | toJson }},
+    "webOrigins" : {{ .Values.realm.activiti.webOrigins | toJson }},
     "notBefore" : 0,
     "bearerOnly" : false,
     "consentRequired" : false,

--- a/activiti-keycloak/templates/realm-secret.yaml
+++ b/activiti-keycloak/templates/realm-secret.yaml
@@ -8,5 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-{{ (.Files.Glob "files/activiti-realm.json").AsSecrets | indent 2 }}
+  "activiti-realm.json": {{ tpl (.Files.Get "files/activiti-realm.json") . | b64enc | quote }}
 {{- end }}

--- a/activiti-keycloak/values.yaml
+++ b/activiti-keycloak/values.yaml
@@ -19,7 +19,7 @@ keycloak:
 #          more_set_headers 'Access-Control-Allow-Credentials: true';
 #          more_set_headers 'Access-Control-Allow-Headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization"';
 #          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+#        nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     livenessProbe:
       initialDelaySeconds: 140
     extraVolumes: |
@@ -52,6 +52,16 @@ realm:
 #      credentials:
 #      - type: password
 #        value: password
+#      realmRoles:
+#        - "offline_access"
+#        - "uma_authorization"
+#        - "ACTIVITI_USER"
+#      clientRoles:
+#        account:
+#          - "manage-account"
+#          - "view-profile"
+#      groups:
+#        - "hr"
   activiti:
     webOrigins:
       - "*"

--- a/activiti-keycloak/values.yaml
+++ b/activiti-keycloak/values.yaml
@@ -8,19 +8,18 @@ keycloak:
       dbVendor: H2
     ingress:
       enabled: false
-      annotations:
-#      path: /
+      proxyBufferSize: "16k"
 #      hosts:
-#        - "jx-staging-quickstart-http.jx-staging.activiti.envalfresco.com"
+#        - "activiti-keycloak.REPLACEME"
 #      annotations:
 #        kubernetes.io/ingress.class: nginx
 #        nginx.ingress.kubernetes.io/rewrite-target: /
 #        nginx.ingress.kubernetes.io/configuration-snippet: |
-#          add_header Access-Control-Allow-Methods "POST, GET, OPTIONS, PUT, PATCH, DELETE";
-#          add_header Access-Control-Allow-Credentials true;
-#          add_header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization";
-# don't add the allowed origin automatically as then we get twice (because in realm config too?)
-#          add_header Access-Control-Allow-Origin $http_origin;
+#          more_set_headers 'Access-Control-Allow-Methods: "POST, GET, OPTIONS, PUT, PATCH, DELETE"';
+#          more_set_headers 'Access-Control-Allow-Credentials: true';
+#          more_set_headers 'Access-Control-Allow-Headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization"';
+#          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     livenessProbe:
       initialDelaySeconds: 140
     extraVolumes: |
@@ -36,9 +35,25 @@ keycloak:
       /opt/jboss/keycloak/bin/add-user.sh -u admin -p admin
       /opt/jboss/keycloak/bin/add-user-keycloak.sh -r master -u admin -p admin
       cp /realm/activiti-realm.json .
-      sed -i 's/activiti-cloud-demo-ui:30082/jx-staging-quickstart-http.jx-staging.activiti.envalfresco.com/g' activiti-realm.json
-      sed -i 's/activiti-cloud-demo-ui:\*/jx-staging-quickstart-http.jx-staging.activiti.envalfresco.com:*/g' activiti-realm.json
-      sed -i 's/placeholder.com/jx-staging-quickstart-http.jx-staging.activiti.envalfresco.com:*/g' activiti-realm.json
-      sed -i 's/dummy.com/gw.jx-staging.activiti.envalfresco.com:*/g' activiti-realm.json
-      sed -i 's/activiti-cloud-sso-idm-kub:30082/gw.jx-staging.activiti.envalfresco.com/g' activiti-realm.json
-      sed -i 's/activiti-cloud-demo-ui:3000/activiti-cloud-demo-ui.jx-staging.activiti.envalfresco.com/g' activiti-realm.json
+
+#extensions to the activiti base realm
+realm:
+#  extraRealmRoles:
+#    - name: "ACTIVITI_TEST"
+#    - name: "ACTIVITI_SUPER"
+#  extraGroups:
+#    - name: "ACTIVITI_GROUP"
+#  extraUsers:
+#    - username: superadminuser
+#      enabled: true
+#      firstName: "Super Admin"
+#      lastName: User
+#      email: "superadminuser@test.com"
+#      credentials:
+#      - type: password
+#        value: password
+  activiti:
+    webOrigins:
+      - "*"
+    redirectUris:
+      - "*"


### PR DESCRIPTION
This would allow users of the chart to expand the realm with their own definitions for users, groups and roles as well as overriding the redirectUris and origins

Have tried this out by deploying the chart and am able to see my changes reflected in the admin console, including adding extra users