### PR TITLE
fix: remove graphiql ingress annotations

### DIFF
--- a/activiti-cloud-notifications-graphql/templates/ingress.yaml
+++ b/activiti-cloud-notifications-graphql/templates/ingress.yaml
@@ -65,8 +65,6 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/add-base-url: "true"    
     {{- range $key, $value := .Values.global.gateway.ingress.annotations }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}


### PR DESCRIPTION
This PR patches /graphiql ingress annotations for 7.0.0.GA to fix Activiti/Activiti#2460