### PR TITLE
feat: Common chart registry pull secrets support, tlsacme config, unset base ingress annotations, remove rewrite-target from Modeler

### DIFF
--- a/activiti-cloud-audit/templates/deployment.yaml
+++ b/activiti-cloud-audit/templates/deployment.yaml
@@ -52,13 +52,13 @@ spec:
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" $ | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.realm }}
+        {{- if include "common.keycloak-realm" . }}
         - name: ACT_KEYCLOAK_REALM
-          value: {{ .Values.global.keycloak.realm | quote }}
+          value: {{ include "common.keycloak-realm" . | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.resource }}
+        {{- if include "common.keycloak-resource" . }}
         - name: ACT_KEYCLOAK_RESOURCE
-          value: {{ .Values.global.keycloak.resource | quote }}
+          value: {{ include "common.keycloak-resource" . | quote }}
         {{- end }}
 {{- if .Values.postgres.enable }}
         - name: SPRING_DATASOURCE_URL

--- a/activiti-cloud-audit/templates/deployment.yaml
+++ b/activiti-cloud-audit/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-audit/values.yaml
+++ b/activiti-cloud-audit/values.yaml
@@ -48,7 +48,6 @@ image:
   tag: 7.0.0.GA
   pullPolicy: IfNotPresent
 service:
-  name: audit
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/activiti-cloud-connector/templates/configmap.yaml
+++ b/activiti-cloud-connector/templates/configmap.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
 data:
   application.properties: |-
 {{- range $key, $value := .Values.configMap }}

--- a/activiti-cloud-connector/templates/deployment.yaml
+++ b/activiti-cloud-connector/templates/deployment.yaml
@@ -48,18 +48,18 @@ spec:
           value: {{ .Values.global.rabbitmq.username.value }}
         - name: SPRING_RABBITMQ_PASSWORD
           value: {{ .Values.global.rabbitmq.password.value }}
-{{- if include "common.keycloak-url" $ }}
+        {{- if include "common.keycloak-url" $ }}
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" $ | quote }}
-{{- end }}
-{{- if .Values.global.keycloak.realm }}
+        {{- end }}
+        {{- if include "common.keycloak-realm" . }}
         - name: ACT_KEYCLOAK_REALM
-          value: {{ .Values.global.keycloak.realm | quote }}
-{{- end }}
-{{- if .Values.global.keycloak.resource }}
+          value: {{ include "common.keycloak-realm" . | quote }}
+        {{- end }}
+        {{- if include "common.keycloak-resource" . }}
         - name: ACT_KEYCLOAK_RESOURCE
-          value: {{ .Values.global.keycloak.resource | quote }}
-{{- end }}
+          value: {{ include "common.keycloak-resource" . | quote }}
+        {{- end }}
         - name: EUREKA_CLIENT_ENABLED
           value: "false"
         - name: ACTIVITI_CLOUD_SERVICES_METADATA_EUREKA_STATIC_ENABLED

--- a/activiti-cloud-connector/templates/deployment.yaml
+++ b/activiti-cloud-connector/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-connector/templates/role.yaml
+++ b/activiti-cloud-connector/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
 rules:
 - apiGroups:
   - extensions

--- a/activiti-cloud-connector/templates/rolebinding.yaml
+++ b/activiti-cloud-connector/templates/rolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
 subjects:
 - kind: ServiceAccount
 {{- if .Values.service.name }}

--- a/activiti-cloud-connector/templates/rolebinding.yaml
+++ b/activiti-cloud-connector/templates/rolebinding.yaml
@@ -10,6 +10,10 @@ roleRef:
   name: {{ .Chart.Name }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/activiti-cloud-connector/templates/serviceaccount.yaml
+++ b/activiti-cloud-connector/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/activiti-cloud-connector/templates/serviceaccount.yaml
+++ b/activiti-cloud-connector/templates/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
 {{- end -}}

--- a/activiti-cloud-connector/values.yaml
+++ b/activiti-cloud-connector/values.yaml
@@ -42,7 +42,6 @@ image:
   tag: 7.0.0.GA
   pullPolicy: IfNotPresent
 service:
-  name: example-cloud-connector
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/activiti-cloud-demo-ui/templates/deployment.yaml
+++ b/activiti-cloud-demo-ui/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           value: {{ include "common.keycloak-url" $ | quote }}
         {{- end }}
         - name: ACT_IDM_CLIENT_ID
-          value: "{{ .Values.global.keycloak.client }}"
+          value: "{{ include "common.keycloak-client" . | quote }}"
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 8 }}
 {{- end }}

--- a/activiti-cloud-demo-ui/templates/deployment.yaml
+++ b/activiti-cloud-demo-ui/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-demo-ui/values.yaml
+++ b/activiti-cloud-demo-ui/values.yaml
@@ -19,7 +19,6 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 service:
-  name: activiti-cloud-demo-ui
   type: ClusterIP
   externalPort: 80
   internalPort: 3000

--- a/activiti-cloud-events-adapter/templates/deployment.yaml
+++ b/activiti-cloud-events-adapter/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-events-adapter/values.yaml
+++ b/activiti-cloud-events-adapter/values.yaml
@@ -29,7 +29,6 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 service:
-  name: event-adapter
   type: ClusterIP
   externalPort: 8080
   internalPort: 8080

--- a/activiti-cloud-full-example/values.yaml
+++ b/activiti-cloud-full-example/values.yaml
@@ -51,10 +51,23 @@ global:
 
 activiti-cloud-modeling:
   enabled: true
+  service:
+    name: activiti-cloud-modeling
+  ingress:
+    enabled: true
+    frontend:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/"
+    backend:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/"
+      
 
 application:
   runtime-bundle:
     enabled: true
+    service: 
+      name: rb-my-app
     image:
       pullPolicy: Always
     # extraEnv: |
@@ -80,6 +93,8 @@ application:
     #     value: "*"
 
   activiti-cloud-query:
+    service: 
+      name: query
     image:
       pullPolicy: Always
     # extraEnv: |
@@ -106,15 +121,21 @@ application:
 
   activiti-cloud-connector:
     enabled: true
+    service: 
+      name: example-cloud-connector
     image:
       pullPolicy: Always
 
   activiti-cloud-notifications-graphql:
     enabled: true
+    service: 
+      name: activiti-cloud-notifications
     image:
       pullPolicy: Always
 
   activiti-cloud-audit:
+    service: 
+      name: audit
     image:
       pullPolicy: Always
     # extraEnv: |
@@ -154,6 +175,8 @@ infrastructure:
           sed -i 's/placeholder.com/*/g' activiti-realm.json
   
   activiti-cloud-gateway:
+    service:
+      name: activiti-cloud-gateway
     ingress:
       enabled: true
       annotations:

--- a/activiti-cloud-full-example/values.yaml
+++ b/activiti-cloud-full-example/values.yaml
@@ -29,10 +29,10 @@ global:
     ## Set to configure single domain name for all services, i.e. "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
     host: "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ template \"common.gateway-domain\" . }}"
 
-    ## Set to enable HTTPS configuration on all exposed service ingresses
+    ## Set to false enables HTTPS configuration on all urls 
     http: "true"
 
-    ## Set to enable automatic TLS for ingress 
+    ## Set to enable automatic TLS for ingress if https is enabled
     tlsacme: "false"
 
     ## Set to configure gateway domain template, i.e. {{ .Release.Namespace }}.1.3.4.5.nip.io

--- a/activiti-cloud-full-example/values.yaml
+++ b/activiti-cloud-full-example/values.yaml
@@ -9,6 +9,9 @@
 #     http: &http true
 
 global:
+  ## Configure pull secrets for all deployments
+  registryPullSecrets: []
+
   keycloak:
     ## Configure Activiti Keycloak host template, i.e. "activiti-keycloak.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
     host: ""
@@ -26,8 +29,11 @@ global:
     ## Set to configure single domain name for all services, i.e. "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
     host: "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ template \"common.gateway-domain\" . }}"
 
-    ## Set enable TLS configuration on all exposed service ingresses
-    http: true
+    ## Set to enable HTTPS configuration on all exposed service ingresses
+    http: "true"
+
+    ## Set to enable automatic TLS for ingress 
+    tlsacme: "false"
 
     ## Set to configure gateway domain template, i.e. {{ .Release.Namespace }}.1.3.4.5.nip.io
     #  helm upgrade activiti . --install --set global.gateway.domain=1.2.3.4.nip.io
@@ -41,6 +47,7 @@ global:
     # host: "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
     # domain: *domain ## Sync with Jx expose controller domain conig 
     # http: *http ## Sync with Jx expose controller http conig
+    # tlsacme: *tlsacme ## Sync with Jx expose controller tlsacme conig
 
 activiti-cloud-modeling:
   enabled: true

--- a/activiti-cloud-gateway/templates/deployment.yaml
+++ b/activiti-cloud-gateway/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-gateway/values.yaml
+++ b/activiti-cloud-gateway/values.yaml
@@ -13,7 +13,6 @@ image:
   tag: 7.0.0.GA
   pullPolicy: IfNotPresent
 service:
-  name: activiti-cloud-gateway
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}-backend

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -79,9 +79,9 @@ spec:
         image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
         env:
         - name: APP_CONFIG_OAUTH2_HOST
-          value: {{ include "common.keycloak-url" . }}/realms/{{ .Values.global.keycloak.realm }}
+          value: {{ include "common.keycloak-url" . }}/realms/{{ include "common.keycloak-realm" . }}
         - name: APP_CONFIG_OAUTH2_CLIENTID
-          value: {{ .Values.global.keycloak.client }}
+          value: {{ include "common.keycloak-client" . | quote }}
         - name: API_URL
 {{- if .Values.backend.url }}
           value: {{ .Values.backend.url }}

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: SERVER_PORT
           value: "{{ .Values.service.backend.internalPort }}"
         - name: ACT_KEYCLOAK_URL
-          value: {{ include "common.keycloak-url" $ | quote }}
+          value: {{ include "common.keycloak-url" . | quote }}
         - name: ACTIVITI_CLOUD_MODELING_URL
           value: "localhost:{{ .Values.service.backend.internalPort }}"
 {{- with .Values.backend.extraEnv }}
@@ -79,7 +79,7 @@ spec:
         image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
         env:
         - name: APP_CONFIG_OAUTH2_HOST
-          value: {{ include "common.keycloak-url" $ }}/realms/{{ .Values.global.keycloak.realm }}
+          value: {{ include "common.keycloak-url" . }}/realms/{{ .Values.global.keycloak.realm }}
         - name: APP_CONFIG_OAUTH2_CLIENTID
           value: {{ .Values.global.keycloak.client }}
         - name: API_URL

--- a/activiti-cloud-modeling/values.yaml
+++ b/activiti-cloud-modeling/values.yaml
@@ -132,7 +132,6 @@ ingress:
 
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-headers: "*"
     nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"

--- a/activiti-cloud-modeling/values.yaml
+++ b/activiti-cloud-modeling/values.yaml
@@ -22,7 +22,6 @@ global:
     host: ""
 
 service:
-  name: activiti-cloud-modeling
   type: ClusterIP
   backend:
     externalPort: 80

--- a/activiti-cloud-modeling/values.yaml
+++ b/activiti-cloud-modeling/values.yaml
@@ -135,6 +135,8 @@ ingress:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-headers: "*"
     nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+    ## Should skip annotation if present in the base chart by setting value to "null" literal
+    #nginx.ingress.kubernetes.io/rewrite-target: "null"
 
   ## Set to true to enable websockets
   ws:

--- a/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -44,13 +44,13 @@ spec:
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" $ | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.realm }}
+        {{- if include "common.keycloak-realm" . }}
         - name: ACT_KEYCLOAK_REALM
-          value: {{ .Values.global.keycloak.realm | quote }}
+          value: {{ include "common.keycloak-realm" . | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.resource }}
+        {{- if include "common.keycloak-resource" .  }}
         - name: ACT_KEYCLOAK_RESOURCE
-          value: {{ .Values.global.keycloak.resource  | quote }}
+          value: {{ include "common.keycloak-resource" . | quote }}
         {{- end }}
 {{- if .Values.postgres.enable }}
         - name: SPRING_DATASOURCE_URL

--- a/activiti-cloud-notifications-graphql/values.yaml
+++ b/activiti-cloud-notifications-graphql/values.yaml
@@ -61,7 +61,6 @@ image:
   pullPolicy: IfNotPresent
   
 service:
-  name: activiti-cloud-notifications
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/activiti-cloud-query/templates/deployment.yaml
+++ b/activiti-cloud-query/templates/deployment.yaml
@@ -52,13 +52,13 @@ spec:
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" $ | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.realm }}
+        {{- if include "common.keycloak-realm" . }}
         - name: ACT_KEYCLOAK_REALM
-          value: {{ .Values.global.keycloak.realm | quote }}
+          value: {{ include "common.keycloak-realm" . | quote }}
         {{- end }}
-        {{- if .Values.global.keycloak.resource }}
+        {{- if include "common.keycloak-resource" .  }}
         - name: ACT_KEYCLOAK_RESOURCE
-          value: {{ .Values.global.keycloak.resource | quote }}
+          value: {{ include "common.keycloak-resource" . | quote }}
         {{- end }}
 {{- if .Values.postgres.enable }}
         - name: SPRING_DATASOURCE_URL

--- a/activiti-cloud-query/templates/deployment.yaml
+++ b/activiti-cloud-query/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/activiti-cloud-query/values.yaml
+++ b/activiti-cloud-query/values.yaml
@@ -59,7 +59,6 @@ image:
   tag: 7.0.0.GA
   pullPolicy: IfNotPresent
 service:
-  name: query
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -36,7 +36,13 @@ Create a gateway url template
 {{- end -}}
 
 {{- define "common.gateway-proto" -}}
-{{- tpl "http{{ if (eq .Values.global.gateway.http false) }}s{{ end }}" . -}}
+{{- $http := toString .Values.global.gateway.http -}}
+{{- if eq $http "false" }}https{{else}}http{{ end -}}
+{{- end -}}
+
+{{- define "common.gateway-https-enabled" -}}
+{{- $http := toString .Values.global.gateway.http -}}
+{{- default "" (eq $http "false") -}}
 {{- end -}}
 
 {{- define "common.gateway-host" -}}

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -88,3 +88,45 @@ Create default pull secrets
 
 {{- end }}
 {{- end -}}
+
+{{/*
+Create a default keycloak realm
+*/}}
+{{- define "common.keycloak-realm" -}}
+	{{- $common := dict "Values" .Values.common -}} 
+	{{- $noCommon := omit .Values "common" -}} 
+	{{- $overrides := dict "Values" $noCommon -}} 
+	{{- $noValues := omit . "Values" -}} 
+	{{- with merge $noValues $overrides $common -}}
+		{{- $value := .Values.global.keycloak.realm -}}
+		{{- tpl (printf "%s" $value) . -}}
+	{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default keycloak resource
+*/}}
+{{- define "common.keycloak-resource" -}}
+	{{- $common := dict "Values" .Values.common -}} 
+	{{- $noCommon := omit .Values "common" -}} 
+	{{- $overrides := dict "Values" $noCommon -}} 
+	{{- $noValues := omit . "Values" -}} 
+	{{- with merge $noValues $overrides $common -}}
+		{{- $value := .Values.global.keycloak.resource -}}
+		{{- tpl (printf "%s" $value) . -}}
+	{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default keycloak client
+*/}}
+{{- define "common.keycloak-client" -}}
+	{{- $common := dict "Values" .Values.common -}} 
+	{{- $noCommon := omit .Values "common" -}} 
+	{{- $overrides := dict "Values" $noCommon -}} 
+	{{- $noValues := omit . "Values" -}} 
+	{{- with merge $noValues $overrides $common -}}
+		{{- $value := .Values.global.keycloak.client -}}
+		{{- tpl (printf "%s" $value) . -}}
+	{{- end -}}
+{{- end -}}

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -79,11 +79,11 @@ Create default pull secrets
 {{- $noValues := omit . "Values" -}} 
 {{- $values := merge $noValues $overrides $common -}} 
 {{- with $values -}}
-{{- range $value := .Values.global.registryPullSecrets -}}
-- "name": {{ tpl (printf "%s" $value) $values | quote }}
+{{- range $value := .Values.global.registryPullSecrets }}
+- name: {{ tpl (printf "%s" $value) $values | quote }}
 {{- end }}
-{{- range $value := .Values.registryPullSecrets -}}
-- "name": {{ tpl (printf "%s" $value) $values | quote }}
+{{- range $value := .Values.registryPullSecrets }}
+- name: {{ tpl (printf "%s" $value) $values | quote }}
 {{- end }}
 
 {{- end }}

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -69,3 +69,22 @@ Create a gateway url template
 {{- default "" .Values.global.keycloak.enabled -}}
 {{- end -}}
  
+{{/*
+Create default pull secrets
+*/}}
+{{- define "common.registry-pull-secrets" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- $values := merge $noValues $overrides $common -}} 
+{{- with $values -}}
+{{- range $value := .Values.global.registryPullSecrets -}}
+- "name": {{ tpl (printf "%s" $value) $values | quote }}
+{{- end }}
+{{- range $value := .Values.registryPullSecrets -}}
+- "name": {{ tpl (printf "%s" $value) $values | quote }}
+{{- end }}
+
+{{- end }}
+{{- end -}}

--- a/common/templates/_ingress.tpl
+++ b/common/templates/_ingress.tpl
@@ -59,7 +59,7 @@ Create a default ingress tls.
 	{{- $overrides := dict "Values" $noCommon -}} 
 	{{- $noValues := omit . "Values" -}} 
 	{{- with merge $noValues $overrides $common -}}
-		{{- $tlsacme := toString .Values.global.gateway.tlsacme -}}
+		{{- $tlsacme := include "common.tlsacme-enabled" . -}}
 		{{- $tls := toString .Values.ingress.tls -}}
 		{{- default "" (or (eq $tlsacme "true") (eq $tls "true")) -}}
 	{{- end -}}

--- a/common/templates/_ingress.tpl
+++ b/common/templates/_ingress.tpl
@@ -8,8 +8,17 @@ Create a default tls secret name.
 	{{- $overrides := dict "Values" $noCommon -}} 
 	{{- $noValues := omit . "Values" -}} 
 	{{- with merge $noValues $overrides $common -}}
-		{{- $tlssecretname := default (printf "tls-%s-%s" .Release.Name .Chart.Name) .Values.ingress.tlsSecret -}}
+		{{- $tlsacmename := include "common.tlsacme-secretname" . -}}
+		{{- $tlssecretname := default $tlsacmename .Values.ingress.tlsSecret -}}
 		{{- tpl (printf "%s" $tlssecretname) $ | trunc 48 | trimSuffix "-" -}}
+	{{- end -}}
+{{- end -}}
+
+{{- define "common.tlsacme-secretname" -}}
+	{{- if include "common.tlsacme-enabled" . -}}
+		{{- printf "tls-%s-%s" .Release.Name .Chart.Name -}}
+	{{- else -}}
+		{{- printf "" -}}
 	{{- end -}}
 {{- end -}}
 
@@ -50,7 +59,9 @@ Create a default ingress tls.
 	{{- $overrides := dict "Values" $noCommon -}} 
 	{{- $noValues := omit . "Values" -}} 
 	{{- with merge $noValues $overrides $common -}}
-		{{- default "" (or (eq .Values.global.gateway.http false) .Values.ingress.tls) -}}
+		{{- $tlsacme := toString .Values.global.gateway.tlsacme -}}
+		{{- $tls := toString .Values.ingress.tls -}}
+		{{- default "" (or (eq $tlsacme "true") (eq $tls "true")) -}}
 	{{- end -}}
 {{- end -}}
 
@@ -69,11 +80,24 @@ Create default ingress annotations
 {{ $key }}: {{ tpl (printf "%s" $value) $values | quote }}
 {{- end }}
 {{- range $key, $value := .Values.ingress.annotations }}
+{{- if (ne (toString $value) "null") }}
 {{ $key }}: {{ tpl (printf "%s" $value) $values | quote }}
 {{- end }}
-{{- if or (eq .Values.global.gateway.http false) .Values.ingress.tls }}
-{{ tpl "kubernetes.io/tls-acme: \"true\"" . }}
+{{- end }}
+
+{{- if include "common.tlsacme-enabled" . }}
+{{ "kubernetes.io/tls-acme" }}: {{ include "common.tlsacme-enabled" . | quote }}
 {{- end }}
 
 {{- end }}
 {{- end -}}
+
+{{/*
+Default tlsacme-enabled template
+*/}}
+{{- define "common.tlsacme-enabled" -}}
+	{{- $http := toString .Values.global.gateway.http -}}
+	{{- $tlsacme := toString .Values.global.gateway.tlsacme -}}
+	{{- default "" (and (eq $tlsacme "true") (eq $http "false")) -}}
+{{- end -}}
+

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -26,6 +26,12 @@ global:
     resource: "activiti"
     client: "activiti"
 
+  ## Configure pull secrets for all deployments
+  registryPullSecrets: []
+
+## Configures additional pull secrets for this deployment
+registryPullSecrets: []
+
 ingress:
   ## Set this to true in order to enable TLS on the ingress record
   tls: 

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -17,6 +17,11 @@ global:
     ## Configure default keycloak host template, i.e "activiti-keycloak.{{ .Values.global.gateway.domain }}"
     host: ""
 
+    ## Configure default Keycloak realm
+    realm: "activiti"
+    resource: "activiti"
+    client: "activiti"
+
 ingress:
   ## Set this to true in order to enable TLS on the ingress record
   tls: false

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -6,8 +6,12 @@ global:
     domain: ""
     ## Confige default gateway host Helm template, i.e. "activiti-cloud-gateway.{{ .Values.global.gateway.domain }}"
     host: ""
-    ## Set to false to enable tls for ingresses
-    http: true 
+    ## Toggle creating http or https ingress rules, supports literal or boolean values
+    http: true
+
+    ## Used to enable automatic TLS for ingress if http is false
+    tlsacme: false
+
   keycloak:
     enabled: true
     ## Overrides gateway host configuration
@@ -24,7 +28,7 @@ global:
 
 ingress:
   ## Set this to true in order to enable TLS on the ingress record
-  tls: false
+  tls: 
 
   ## Empty default. Each ingress should provide its own value or template
   path: 

--- a/runtime-bundle/templates/configmap.yaml
+++ b/runtime-bundle/templates/configmap.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
 data:
   application.properties: |-
 {{- range $key, $value := .Values.configMap }}

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -68,18 +68,18 @@ spec:
           value: {{ .Values.global.rabbitmq.username.value }}
         - name: SPRING_RABBITMQ_PASSWORD
           value: {{ .Values.global.rabbitmq.password.value }}
-{{- if include "common.keycloak-enabled" $ }}
+        {{- if include "common.keycloak-enabled" $ }}
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" $ | quote }}
-{{- end }}
-{{- if .Values.global.keycloak.realm }}
+        {{- end }}
+        {{- if include "common.keycloak-realm" . }}
         - name: ACT_KEYCLOAK_REALM
-          value: {{ .Values.global.keycloak.realm | quote }}
-{{- end }}
-        {{- if .Values.global.keycloak.resource }}
+          value: {{ include "common.keycloak-realm" . | quote }}
+        {{- end }}
+        {{- if include "common.keycloak-resource" .  }}
         - name: ACT_KEYCLOAK_RESOURCE
-          value: {{ .Values.global.keycloak.resource | quote }}
-{{- end }}
+          value: {{ include "common.keycloak-resource" . | quote }}
+        {{- end }}
 {{- if .Values.postgres.enable }}
         - name: SPRING_DATASOURCE_URL
           {{- if .Values.postgres.uri }}

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.registryPullSecrets }}
+{{- if include "common.registry-pull-secrets" . }}
       imagePullSecrets:
-      - name: {{ .Values.registryPullSecrets }}
+      {{- include "common.registry-pull-secrets" . | indent 6 }}
 {{- end }}
     {{- if or .Values.postgres.enable .Values.extraInitContainers }}
       initContainers:

--- a/runtime-bundle/templates/role.yaml
+++ b/runtime-bundle/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
 rules:
 - apiGroups:
   - extensions

--- a/runtime-bundle/templates/rolebinding.yaml
+++ b/runtime-bundle/templates/rolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Chart.Name }}
+  name: {{ template "fullname" . }}
 subjects:
 - kind: ServiceAccount
 {{- if .Values.service.name }}

--- a/runtime-bundle/templates/rolebinding.yaml
+++ b/runtime-bundle/templates/rolebinding.yaml
@@ -10,6 +10,10 @@ roleRef:
   name: {{ .Chart.Name }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/runtime-bundle/templates/serviceaccount.yaml
+++ b/runtime-bundle/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/runtime-bundle/templates/serviceaccount.yaml
+++ b/runtime-bundle/templates/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.name }}
   name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
 {{- end -}}

--- a/runtime-bundle/values.yaml
+++ b/runtime-bundle/values.yaml
@@ -67,7 +67,6 @@ image:
   tag: 7.0.0.GA
   pullPolicy: IfNotPresent
 service:
-  name: rb-my-app
   type: ClusterIP
   externalPort: 80
   internalPort: 8080


### PR DESCRIPTION
This PR contains the following changes:

Bug fixes:
* fix: remove rewrite-target annotation from modeler
* fix: adjust deployment template scopes to default
* fix: unset specific ingress annotation using "null" value
* fix: ServiceAccount "" is invalid: metadata.name
* fix: move service names overrides to full example chart
* fix: set release scope for role, rolebinding and serviceaccount

New Features:
* feat: add global Keycloak realm settings to common chart values
* feat: add tlsacme config to enable automatic TLS for ingresses if https is enabled
* feat: add common.registry-pull-secrets template
* feat: add common.keycloak props template

