### PR TITLE
Support for Alfresco Process Application Deployment

### DIFF
--- a/activiti-cloud-audit/templates/deployment.yaml
+++ b/activiti-cloud-audit/templates/deployment.yaml
@@ -124,9 +124,7 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-audit/templates/deployment.yaml
+++ b/activiti-cloud-audit/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -140,7 +140,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/activiti-cloud-audit/values.yaml
+++ b/activiti-cloud-audit/values.yaml
@@ -101,8 +101,4 @@ ingress:
   tlsSecret: 
 
   ## Ingress annotations done as key:value pairs
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+  annotations: {}

--- a/activiti-cloud-connector/templates/deployment.yaml
+++ b/activiti-cloud-connector/templates/deployment.yaml
@@ -68,9 +68,7 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-connector/templates/deployment.yaml
+++ b/activiti-cloud-connector/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -84,7 +84,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}    
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/activiti-cloud-connector/values.yaml
+++ b/activiti-cloud-connector/values.yaml
@@ -83,13 +83,7 @@ ingress:
   tlsSecret: 
 
   ## Ingress annotations done as key:value pairs
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Port, X-Forwarded-Prefix,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-CSRF-Token,Access-Control-Request-Headers,Access-Control-Request-Method,accept,Keep-Alive"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
-
+  annotations: {}
 
 #only needed when using sck8s
 rbac:

--- a/activiti-cloud-demo-ui/templates/deployment.yaml
+++ b/activiti-cloud-demo-ui/templates/deployment.yaml
@@ -38,9 +38,7 @@ spec:
         {{- end }}
         - name: ACT_IDM_CLIENT_ID
           value: "{{ include "common.keycloak-client" . | quote }}"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-demo-ui/templates/deployment.yaml
+++ b/activiti-cloud-demo-ui/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -53,7 +53,7 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/activiti-cloud-demo-ui/values.yaml
+++ b/activiti-cloud-demo-ui/values.yaml
@@ -51,11 +51,11 @@ ingress:
   ## Set to true to enable ingress record generation
   enabled: true
 
-  path: /
+  path: /activiti-cloud-demo-ui
 
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hostName: "{{ include \"name\" $ }}.{{ include \"common.gateway-host\" $ }}"
+  hostName: 
   
   ## Set this to true in order to enable TLS on the ingress record
   tls: 
@@ -63,11 +63,7 @@ ingress:
   ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
   tlsSecret: 
 
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+  annotations: {}
 
 ## Allows the specification of additional environment variables
 extraEnv: |

--- a/activiti-cloud-full-example/values.yaml
+++ b/activiti-cloud-full-example/values.yaml
@@ -12,6 +12,15 @@ global:
   ## Configure pull secrets for all deployments
   registryPullSecrets: []
 
+  # Use Yaml formatted string to add extra environment properties to all deployments, i.e.
+  extraEnv: |
+    # - name: SERVER_USEFORWARDHEADERS
+    #   value: "true"
+    # - name: SERVER_TOMCAT_INTERNALPROXIES
+    #   value: ".*"
+    # - name: MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE
+    #   value: "*"
+
   keycloak:
     ## Configure Activiti Keycloak host template, i.e. "activiti-keycloak.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
     host: ""
@@ -24,6 +33,11 @@ global:
     realm: "activiti"
     resource: "activiti"
     client: "activiti"
+
+    ## Use Yaml formatted string to add keycloak properties to deployments
+    extraEnv: |
+      # - name: KEYCLOAK_USERESOURCEROLEMAPPINGS
+      #   value: "false" 
 
   gateway:
     ## Set to configure single domain name for all services, i.e. "activiti-cloud-gateway.{{ .Release.Namespace }}.{{ .Values.global.gateway.domain }}"
@@ -49,19 +63,22 @@ global:
     # http: *http ## Sync with Jx expose controller http conig
     # tlsacme: *tlsacme ## Sync with Jx expose controller tlsacme conig
 
+
 activiti-cloud-modeling:
   enabled: true
   service:
     name: activiti-cloud-modeling
   ingress:
-    enabled: true
+    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-headers: "*"
+      nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
     frontend:
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: "/"
+      annotations: {}
     backend:
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: "/"
-      
+      annotations: {}
 
 application:
   runtime-bundle:
@@ -184,3 +201,4 @@ infrastructure:
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/cors-allow-headers: "*"
         nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+

--- a/activiti-cloud-gateway/templates/deployment.yaml
+++ b/activiti-cloud-gateway/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -48,7 +48,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}  
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/activiti-cloud-gateway/values.yaml
+++ b/activiti-cloud-gateway/values.yaml
@@ -18,12 +18,6 @@ service:
   internalPort: 8080
   annotations:
     fabric8.io/expose: "false"
-    fabric8.io/ingress.annotations: |-
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/rewrite-target: /
-      nginx.ingress.kubernetes.io/enable-cors: true
-      nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-      nginx.ingress.kubernetes.io/x-forwarded-prefix: true
 resources:
   limits:
     cpu: 1
@@ -61,8 +55,4 @@ ingress:
   tlsSecret: 
 
   ## Ingress annotations done as key:value pairs
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+  annotations: {}

--- a/activiti-cloud-modeling/templates/_helpers.tpl
+++ b/activiti-cloud-modeling/templates/_helpers.tpl
@@ -44,3 +44,32 @@ Create a ws-graphql ingress path.
 		{{- tpl (printf "%s%s" $basePath $value) . -}}
 	{{- end -}}
 {{- end -}}
+
+{{/*
+Create a default extra env templated values for backend
+*/}}
+{{- define "activiti-cloud-modeling.extra-env-backend" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with merge $noValues $overrides $common -}}
+{{- include "common.extra-env" . -}}
+{{- tpl .Values.backend.extraEnv . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default extra env templated values for frontend
+*/}}
+{{- define "activiti-cloud-modeling.extra-env-frontend" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with merge $noValues $overrides $common -}}
+{{- include "common.extra-env" . -}}
+{{- tpl .Values.frontend.extraEnv . -}}
+{{- end -}}
+{{- end -}}
+

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
           value: "{{ .Values.service.backend.internalPort }}"
         - name: ACT_KEYCLOAK_URL
           value: {{ include "common.keycloak-url" . | quote }}
+        - name: ACT_KEYCLOAK_REALM
+          value: {{ include "common.keycloak-realm" . | quote }}
+        - name: ACT_KEYCLOAK_RESOURCE
+          value: {{ include "common.keycloak-resource" . | quote }}
         - name: ACTIVITI_CLOUD_MODELING_URL
           value: "localhost:{{ .Values.service.backend.internalPort }}"
 {{- with .Values.backend.extraEnv }}

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -49,9 +49,7 @@ spec:
           value: {{ include "common.keycloak-resource" . | quote }}
         - name: ACTIVITI_CLOUD_MODELING_URL
           value: "localhost:{{ .Values.service.backend.internalPort }}"
-{{- with .Values.backend.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "activiti-cloud-modeling.extra-env-backend" . | indent 8 }}
         imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.backend.internalPort }}
@@ -104,9 +102,7 @@ spec:
 {{- end }}
         - name: API_PATH_PREFIX
           value: "{{ .Values.backend.prefix }}"
-{{- with .Values.frontend.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "activiti-cloud-modeling.extra-env-frontend" . | indent 8 }}
         imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.frontend.internalPort }}

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - containerPort: {{ .Values.service.backend.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.backend.probePath }}
+            path: {{ tpl .Values.backend.probePath . }}
             port: {{ .Values.service.backend.internalPort }}
           initialDelaySeconds: {{ .Values.backend.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.backend.livenessProbe.periodSeconds }}
@@ -62,7 +62,7 @@ spec:
           failureThreshold: {{ .Values.backend.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.backend.probePath }}
+            path: {{ tpl .Values.backend.probePath . }}
             port: {{ .Values.service.backend.internalPort }}
           initialDelaySeconds: {{ .Values.backend.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.backend.readinessProbe.periodSeconds }}
@@ -108,7 +108,7 @@ spec:
         - containerPort: {{ .Values.service.frontend.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.frontend.probePath }}
+            path: {{ tpl .Values.frontend.probePath . }}
             port: {{ .Values.service.frontend.internalPort }}
           initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
@@ -117,7 +117,7 @@ spec:
           failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.frontend.probePath }}
+            path: {{ tpl .Values.frontend.probePath . }}
             port: {{ .Values.service.frontend.internalPort }}
           initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds }}

--- a/activiti-cloud-modeling/values.yaml
+++ b/activiti-cloud-modeling/values.yaml
@@ -129,13 +129,7 @@ ingress:
   ## Set to override global.gateway.host value, i.e. "modeler.{{ include \"common.gateway-domain\" . }}"
   hostName: 
 
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
-    ## Should skip annotation if present in the base chart by setting value to "null" literal
-    #nginx.ingress.kubernetes.io/rewrite-target: "null"
+  annotations: {}
 
   ## Set to true to enable websockets
   ws:

--- a/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -132,7 +132,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -116,9 +116,7 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-notifications-graphql/templates/ingress.yaml
+++ b/activiti-cloud-notifications-graphql/templates/ingress.yaml
@@ -9,17 +9,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*" 
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,PUT,POST,DELETE,PATCH,OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"   
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
-    nginx.ingress.kubernetes.io/affinity: cookie
-    nginx.ingress.kubernetes.io/session-cookie-name: "activiti-cloud-notifications-graphql-route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "md5"
-    nginx.ingress.kubernetes.io/session-cookie-path: "/"
     {{- include "common.ingress-annotations" . | indent 4 }} 
 spec:
   rules:

--- a/activiti-cloud-notifications-graphql/values.yaml
+++ b/activiti-cloud-notifications-graphql/values.yaml
@@ -104,4 +104,16 @@ ingress:
   ws: 
     enabled: true
     path: /ws/graphql
-  annotations: {}
+  annotations: 
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*" 
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,PUT,POST,DELETE,PATCH,OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"   
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-name: "activiti-cloud-notifications-graphql-route"
+    nginx.ingress.kubernetes.io/session-cookie-hash: "md5"
+    nginx.ingress.kubernetes.io/session-cookie-path: "/"
+    

--- a/activiti-cloud-query/templates/deployment.yaml
+++ b/activiti-cloud-query/templates/deployment.yaml
@@ -124,9 +124,7 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-query/templates/deployment.yaml
+++ b/activiti-cloud-query/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -140,7 +140,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/activiti-cloud-query/values.yaml
+++ b/activiti-cloud-query/values.yaml
@@ -108,9 +108,4 @@ ingress:
   tlsSecret: 
 
   ## Ingress annotations done as key:value pairs
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Port, X-Forwarded-Prefix,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-CSRF-Token,Access-Control-Request-Headers,Access-Control-Request-Method,accept,Keep-Alive"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+  annotations: {}

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -130,3 +130,19 @@ Create a default keycloak client
 		{{- tpl (printf "%s" $value) . -}}
 	{{- end -}}
 {{- end -}}
+
+{{/*
+Create a default extra env templated values 
+*/}}
+{{- define "common.extra-env" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with merge $noValues $overrides $common -}}
+{{- tpl .Values.global.keycloak.extraEnv . -}}
+{{- tpl .Values.global.extraEnv . -}}
+{{- tpl .Values.extraEnv . -}}
+{{- end -}}
+{{- end -}}
+

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -26,8 +26,17 @@ global:
     resource: "activiti"
     client: "activiti"
 
+    ## Adds Keycloak extraEnv to deployments
+    extraEnv: ""
+
   ## Configure pull secrets for all deployments
   registryPullSecrets: []
+
+  ## Adds global extraEnv to deployments
+  extraEnv: ""
+
+## Adds extraEnv to deployments
+extraEnv: ""
 
 ## Configures additional pull secrets for this deployment
 registryPullSecrets: []

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -160,7 +160,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -144,9 +144,7 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
-{{- with .Values.extraEnv }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+{{ include "common.extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/runtime-bundle/values.yaml
+++ b/runtime-bundle/values.yaml
@@ -111,13 +111,7 @@ ingress:
   tlsSecret: 
 
   ## Ingress annotations done as key:value pairs
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Port, X-Forwarded-Prefix,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-CSRF-Token,Access-Control-Request-Headers,Access-Control-Request-Method,accept,Keep-Alive"
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
-
+  annotations: {}
 
 #only needed when using sck8s
 rbac:


### PR DESCRIPTION
This PR contains the following changes to streamline APAD:

Fixes: 
* remove nginx rewrite-target annotation to work with v0.22.0 (Fixes Activiti/Activiti#2476)
* inject global Keycloak realm env variable into Modeler backend

New Features:
* add template support for probePath values
* add common.extra-env template for global extraEnvs
