### PR TITLE
feat: add common.keycloak-extra-env template

### DIFF
--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -140,9 +140,21 @@ Create a default extra env templated values
 {{- $overrides := dict "Values" $noCommon -}} 
 {{- $noValues := omit . "Values" -}} 
 {{- with merge $noValues $overrides $common -}}
-{{- tpl .Values.global.keycloak.extraEnv . -}}
 {{- tpl .Values.global.extraEnv . -}}
 {{- tpl .Values.extraEnv . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a keycloak extra env templated values 
+*/}}
+{{- define "common.keycloak-extra-env" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with merge $noValues $overrides $common -}}
+{{- tpl .Values.global.keycloak.extraEnv . -}}
 {{- end -}}
 {{- end -}}
 

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -145,6 +145,7 @@ spec:
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
 {{ include "common.extra-env" . | indent 8 }}
+{{ include "common.keycloak-extra-env" . | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:


### PR DESCRIPTION
This PR extracts keycloak extraEnv global configuration into separate common.keycloak-extra-env template to be able to selectively apply global Keycloak env properties into deployments that need it, i.e. ADF apps, runtime-bundle.