### PR TITLE
modeler backend env var change

### DIFF
--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: {{ include "common.keycloak-url" . }}/realms/{{ include "common.keycloak-realm" . }}
         - name: APP_CONFIG_OAUTH2_CLIENTID
           value: {{ include "common.keycloak-client" . | quote }}
-        - name: API_URL
+        - name: APP_CONFIG_BPM_HOST
 {{- if .Values.backend.url }}
           value: {{ .Values.backend.url }}
 {{- else }}


### PR DESCRIPTION
https://issues.alfresco.com/jira/browse/APM-840

Needed as a result of the PR below. But note that activiti-cloud-charts currently still references the GA images. Don't actually need to change the public-facing charts until image for this new modeler version is in the charts and it is **not** included in 7.0.0.SR1 as that release was already started before referenced PR was opened