### PR TITLE
feat: add Jx GitOps env expose configuration template support

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Activiti Cloud Common Templates 
 icon: "https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png"
 name: common
-version: 1.1.2
+version: 1.1.3

--- a/common/templates/_ingress.tpl
+++ b/common/templates/_ingress.tpl
@@ -96,8 +96,8 @@ Create default ingress annotations
 Default tlsacme-enabled template
 */}}
 {{- define "common.tlsacme-enabled" -}}
-	{{- $http := toString .Values.global.gateway.http -}}
-	{{- $tlsacme := toString .Values.global.gateway.tlsacme -}}
+	{{- $http := tpl (toString .Values.global.gateway.http) . -}}
+	{{- $tlsacme := tpl (toString .Values.global.gateway.tlsacme) . -}}
 	{{- default "" (and (eq $tlsacme "true") (eq $http "false")) -}}
 {{- end -}}
 

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -41,6 +41,23 @@ extraEnv: ""
 ## Configures additional pull secrets for this deployment
 registryPullSecrets: []
 
+## Allows to template gateway values from Jx Expose controller configuration in GitOps environment, i.e.
+# expose:
+#   config:
+#     domain: 1.2.3.4.nip.io
+#     http: "true"
+#     tlsacme: "false"
+# global:
+#   gateway:
+#     domain: "{{ .Values.expose.config.domain }}"
+#       http: "{{ .Values.expose.config.http }}"
+#       tlsacme: "{{ .Values.expose.config.tlsacme }}"
+expose:
+  config:
+    domain: ""
+    http: "true"
+    tlsacme: "false"
+
 ingress:
   ## Set this to true in order to enable TLS on the ingress record
   tls: 

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -47,11 +47,14 @@ registryPullSecrets: []
 #     domain: 1.2.3.4.nip.io
 #     http: "true"
 #     tlsacme: "false"
+#
 # global:
+#   keycloak:
+#     host: "activiti-keycloak.{{ tpl .Values.global.gateway.domain . }}"
 #   gateway:
 #     domain: "{{ .Values.expose.config.domain }}"
-#       http: "{{ .Values.expose.config.http }}"
-#       tlsacme: "{{ .Values.expose.config.tlsacme }}"
+#     http: "{{ .Values.expose.config.http }}"
+#     tlsacme: "{{ .Values.expose.config.tlsacme }}"
 expose:
   config:
     domain: ""


### PR DESCRIPTION
This PR adds support for Jx GitOps environment Expose controller configuration values, so that environment configuration can be injected via templated `global.gateway` values, i.e.

```yaml
## Allows to template gateway values from Jx Expose controller configuration in GitOps environment, i.e. 
expose: 
  config: 
    domain: 1.2.3.4.nip.io 
    http: "true" 
    tlsacme: "false" 

global: 
  keycloak:
    host: "activiti-keycloak.{{ tpl .Values.global.gateway.domain . }}"
  gateway: 
    domain: "{{ .Values.expose.config.domain }}" 
    http: "{{ .Values.expose.config.http }}" 
    tlsacme: "{{ .Values.expose.config.tlsacme }}" 
```