### PR TITLE
fix generate keycloak host overriden by ingress.hostName

### DIFF
--- a/activiti-keycloak/templates/_helpers.tpl
+++ b/activiti-keycloak/templates/_helpers.tpl
@@ -21,10 +21,9 @@ Create a default name for the keycloak requirement.
 	{{- $overrides := dict "Values" $noCommon -}} 
 	{{- $noValues := omit . "Values" -}} 
 	{{- with merge $noValues $overrides $common -}}
-		{{- $gatewayHost := include "common.gateway-host" . -}} 
-		{{- $keycloakHost := include "common.keycloak-host" . -}} 
-		{{- $ingressHost := default $gatewayHost $keycloakHost -}} 
-		{{- tpl ( printf "%s" $ingressHost ) . -}} 
+		{{- $keycloakHost := include "common.keycloak-host" . -}}
+		{{- $ingressHost := default $keycloakHost .Values.ingress.hostName -}}
+		{{- tpl ( printf "%s" $ingressHost ) . -}}
 	{{- end -}} 
 {{- end -}} 
  

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -9,9 +9,7 @@ Create a keycloak url template
 	{{- $noValues := omit . "Values" -}} 
 	{{- with merge $noValues $overrides $common -}}
 		{{- $proto := include "common.gateway-proto" . -}}
-		{{- $gatewayHost := include "common.gateway-host" . -}}
-		{{- $keycloakHost := include "common.keycloak-host" . -}}
-		{{- $host := default $gatewayHost $keycloakHost -}}
+		{{- $host := include "common.keycloak-host" . -}}
 		{{- $path := include "common.keycloak-path" . -}}
 		{{- $url := printf "%s://%s%s" $proto $host $path -}}
 		{{- $keycloakUrl := default $url .Values.global.keycloak.url -}}
@@ -61,7 +59,7 @@ Create a gateway url template
 {{- end -}}
 
 {{- define "common.keycloak-host" -}}
-{{- $value := default .Values.global.keycloak.host .Values.ingress.hostName -}}
+{{- $value := default (include "common.gateway-host" .) .Values.global.keycloak.host -}}
 {{- tpl (printf "%s" $value) . -}}
 {{- end -}}
 


### PR DESCRIPTION
at the moment if an app declares in its chart an ingress.hostName the keycloak url takes that one rather than the general global keycloak setting breaking the auth, this PR fixes and uses ingress.hostName as default in activiti-keycloak which is the only chart that needs that