### PR TITLE
delete quote in ingress definition

### DIFF
--- a/activiti-keycloak/values.yaml
+++ b/activiti-keycloak/values.yaml
@@ -41,7 +41,7 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers 'Access-Control-Allow-Methods: "POST, GET, OPTIONS, PUT, PATCH, DELETE"';
+      more_set_headers 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, PATCH, DELETE';
       more_set_headers 'Access-Control-Allow-Credentials: true';
       more_set_headers 'Access-Control-Allow-Headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization"';
       more_set_headers 'Access-Control-Allow-Origin: $http_origin';

--- a/activiti-keycloak/values.yaml
+++ b/activiti-keycloak/values.yaml
@@ -43,7 +43,7 @@ ingress:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, PATCH, DELETE';
       more_set_headers 'Access-Control-Allow-Credentials: true';
-      more_set_headers 'Access-Control-Allow-Headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization"';
+      more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization';
       more_set_headers 'Access-Control-Allow-Origin: $http_origin';
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 


### PR DESCRIPTION
The quote in header  ``Access-Control-Allow-Methods: "POST, GET, OPTIONS, PUT, PATCH, DELETE"`` can make it imcompatible with ``Firefox`` , delete the quote to fix the bug

If the response header is ``"POST, GET, OPTIONS, PUT, PATCH, DELETE"`` literally , Firefox would take ``"POST`` as an allowed method instead of the actuall ``POST``.

I've test it on my cloud , when the ``"`` is gone , my angular program would work perfectly well.