### PR TITLE
feat: add common container image templates

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Activiti Cloud Common Templates 
 icon: "https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png"
 name: common
-version: 1.1.4
+version: 1.1.5

--- a/common/templates/_global.tpl
+++ b/common/templates/_global.tpl
@@ -88,6 +88,35 @@ Create default pull secrets
 {{- end -}}
 
 {{/*
+Create container image 
+*/}}
+{{- define "common.container-image" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with  merge $noValues $overrides $common -}} 
+{{- $registry := tpl .Values.image.registry . -}}
+{{- $repository := tpl .Values.image.repository . -}}
+{{- $tag := tpl .Values.image.tag . -}}
+{{- if $registry -}} {{ printf "%s/" $registry }} {{- end -}} {{ print $repository }} {{- if $tag -}} {{ printf ":%s" $tag }} {{- end -}}	
+{{- end }}
+{{- end -}}
+
+{{/*
+Create container image pullPolicy
+*/}}
+{{- define "common.container-image-pull-policy" -}}
+{{- $common := dict "Values" .Values.common -}} 
+{{- $noCommon := omit .Values "common" -}} 
+{{- $overrides := dict "Values" $noCommon -}} 
+{{- $noValues := omit . "Values" -}} 
+{{- with  merge $noValues $overrides $common -}} 
+{{  tpl .Values.image.pullPolicy . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default keycloak realm
 */}}
 {{- define "common.keycloak-realm" -}}

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -32,6 +32,12 @@ global:
   ## Configure pull secrets for all deployments
   registryPullSecrets: []
 
+  image:
+    ## Configure global image values for templates
+    registry: "" # i.e. docker.io | gcr.io/project | quay.io/alfresco
+    tag: "" # i.e. 7.1.0.M1 | {{ .Chart.AppVersion }}
+    pullPolicy: "" # Always | IfNotPresent
+
   ## Adds global extraEnv to deployments
   extraEnv: ""
 
@@ -40,6 +46,13 @@ extraEnv: ""
 
 ## Configures additional pull secrets for this deployment
 registryPullSecrets: []
+
+image:
+  ## Configure image  values for templates
+  registry: '{{ tpl .Values.global.image.registry . | default "" }}'
+  repository: "{{ .Chart.Name }}"
+  tag: '{{ tpl .Values.global.image.tag . | default .Chart.AppVersion | default "latest" }}'
+  pullPolicy: '{{ tpl .Values.global.image.pullPolicy . | default "IfNotPresent" }}'
 
 ## Allows to template gateway values from Jx Expose controller configuration in GitOps environment, i.e.
 # expose:


### PR DESCRIPTION
This PR adds support for common container image templates with global values to be able to customize private Docker registry, image repository, tag, pullPolicy with value templates, i.e.

Given global values:

```
global:
  ## Configure global image values for templates
  image:
    registry: "quay.io"
    pullPolicy: "Always"  
```

And chart values template:

```
## Configure image values for templates
image:
  repository: "activiti/activiti-cloud-audit"
  tag: "7.1.0.M1"
```

When including `common.container-image` template in `deployment.yaml` : 

```
containers:
  - name: {{ .Chart.Name }}
    image: {{ include "common.container-image" . | quote }}
    imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
```

Then result Yaml will be:

```
spec:
  containers:
    - name: activiti-cloud-audit
      image: "quay.io/activiti/activiti-cloud-audit:7.1.0.M1"
      imagePullPolicy: Always
```

