### PR TITLE
fix: update common chart to 1.1.5 

### DIFF
--- a/activiti-cloud-audit/requirements.yaml
+++ b/activiti-cloud-audit/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies: 
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-audit/templates/deployment.yaml
+++ b/activiti-cloud-audit/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"

--- a/activiti-cloud-connector/requirements.yaml
+++ b/activiti-cloud-connector/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies: 
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-connector/templates/deployment.yaml
+++ b/activiti-cloud-connector/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"

--- a/activiti-cloud-demo-ui/requirements.yaml
+++ b/activiti-cloud-demo-ui/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies: 
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-demo-ui/templates/deployment.yaml
+++ b/activiti-cloud-demo-ui/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: ACT_GATEWAY_URL
           value: {{ include "common.gateway-url" $ | quote }}

--- a/activiti-cloud-gateway/requirements.yaml
+++ b/activiti-cloud-gateway/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-gateway/templates/deployment.yaml
+++ b/activiti-cloud-gateway/templates/deployment.yaml
@@ -27,14 +27,14 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: -Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 8 }}
 {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/activiti-cloud-modeling/requirements.yaml
+++ b/activiti-cloud-modeling/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-modeling/templates/_helpers.tpl
+++ b/activiti-cloud-modeling/templates/_helpers.tpl
@@ -73,3 +73,35 @@ Create a default extra env templated values for frontend
 {{- end -}}
 {{- end -}}
 
+{{/* 
+Create container frontend image  
+*/}} 
+{{- define "activiti-cloud-modeling.container-frontend-image" -}} 
+{{- $common := dict "Values" .Values.common -}}  
+{{- $noCommon := omit .Values "common" -}}  
+{{- $overrides := dict "Values" $noCommon -}}  
+{{- $noValues := omit . "Values" -}}  
+{{- with  merge $noValues $overrides $common -}}  
+{{- $registry := tpl .Values.frontend.image.registry . -}} 
+{{- $repository := tpl .Values.frontend.image.repository . -}} 
+{{- $tag := tpl .Values.frontend.image.tag . -}} 
+{{- if $registry -}} {{ printf "%s/" $registry }} {{- end -}} {{ print $repository }} {{- if $tag -}} {{ printf ":%s" $tag }} {{- end -}}	 
+{{- end }} 
+{{- end -}} 
+ 
+{{/* 
+Create container frontend image  
+*/}} 
+{{- define "activiti-cloud-modeling.container-backend-image" -}} 
+{{- $common := dict "Values" .Values.common -}}  
+{{- $noCommon := omit .Values "common" -}}  
+{{- $overrides := dict "Values" $noCommon -}}  
+{{- $noValues := omit . "Values" -}}  
+{{- with  merge $noValues $overrides $common -}}  
+{{- $registry := tpl .Values.backend.image.registry . -}} 
+{{- $repository := tpl .Values.backend.image.repository . -}} 
+{{- $tag := tpl .Values.backend.image.tag . -}} 
+{{- if $registry -}} {{ printf "%s/" $registry }} {{- end -}} {{ print $repository }} {{- if $tag -}} {{ printf ":%s" $tag }} {{- end -}}	 
+{{- end }} 
+{{- end -}} 
+  

--- a/activiti-cloud-modeling/templates/deployment.yaml
+++ b/activiti-cloud-modeling/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}-backend
-        image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+        image: {{ include "activiti-cloud-modeling.container-backend-image" . | quote }}
+        imagePullPolicy: {{ tpl .Values.backend.image.pullPolicy . }}
         resources:
 {{ toYaml .Values.backend.resources | indent 10 }}
         env:
@@ -50,7 +51,6 @@ spec:
         - name: ACTIVITI_CLOUD_MODELING_URL
           value: "localhost:{{ .Values.service.backend.internalPort }}"
 {{ include "activiti-cloud-modeling.extra-env-backend" . | indent 8 }}
-        imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.backend.internalPort }}
         livenessProbe:
@@ -78,7 +78,8 @@ spec:
 {{- end }}
 {{- end }}
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+        image: {{ include "activiti-cloud-modeling.container-frontend-image" . | quote }}
+        imagePullPolicy: {{ tpl .Values.frontend.image.pullPolicy . }}
         env:
         - name: APP_CONFIG_OAUTH2_HOST
           value: {{ include "common.keycloak-url" . }}/realms/{{ include "common.keycloak-realm" . }}
@@ -103,7 +104,6 @@ spec:
         - name: API_PATH_PREFIX
           value: "{{ .Values.backend.prefix }}"
 {{ include "activiti-cloud-modeling.extra-env-frontend" . | indent 8 }}
-        imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.frontend.internalPort }}
         livenessProbe:

--- a/activiti-cloud-notifications-graphql/requirements.yaml
+++ b/activiti-cloud-notifications-graphql/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"

--- a/activiti-cloud-query/requirements.yaml
+++ b/activiti-cloud-query/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies: 
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/activiti-cloud-query/templates/deployment.yaml
+++ b/activiti-cloud-query/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"

--- a/activiti-keycloak/requirements.yaml
+++ b/activiti-keycloak/requirements.yaml
@@ -5,4 +5,4 @@ dependencies:
   condition: keycloak.enabled
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/runtime-bundle/requirements.yaml
+++ b/runtime-bundle/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies: 
 - name: common
   repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+  version: 1.1.5

--- a/runtime-bundle/templates/deployment.yaml
+++ b/runtime-bundle/templates/deployment.yaml
@@ -47,8 +47,8 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "common.container-image" . | quote }}
+        imagePullPolicy: {{ include "common.container-image-pull-policy" . }}
         env:
         - name: JAVA_OPTS
           value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"


### PR DESCRIPTION
This PR updates requirements to use common chart 1.1.5 to add support for global Docker image registry values configuration.

Depends on https://github.com/Activiti/activiti-cloud-charts/pull/77